### PR TITLE
fix: check for empty segmentation key

### DIFF
--- a/label_studio_converter/imports/coco.py
+++ b/label_studio_converter/imports/coco.py
@@ -215,7 +215,7 @@ def convert_coco_to_ls(
             )
             task[out_type][0]['result'].append(item)
 
-        if 'segmentation' in annotation:
+        if 'segmentation' in annotation and len(annotation['segmentation']):
             item = create_segmentation(
                 annotation,
                 categories,


### PR DESCRIPTION
This fixes importing a COCO formatted file with an empty `segmentation` key, e.g.: `{"segmentation":[]}`.

Without this fix, the function `create_segmentation` blows up with an `IndexError` here:

https://github.com/HumanSignal/label-studio-converter/blob/83ac08ce3870de4bb04834314c017735c5f7bb04/label_studio_converter/imports/coco.py#L54