### PR TITLE
fix: Sanitize label name for brushlabel conversion

### DIFF
--- a/label_studio_converter/brush.py
+++ b/label_studio_converter/brush.py
@@ -146,6 +146,12 @@ def save_brush_images_from_annotation(
     )  # sanitize filename
 
     for name in layers:
+        # sanitize label name     
+        sanatized_name = name.replace('/', '-')
+        sanatized_name = sanatized_name.replace('\\', '-')
+        sanatized_name = sanatized_name.replace(' ', '-')
+        sanatized_name = sanatized_name.replace('.', '-')
+        
         filename = os.path.join(
             out_dir,
             'task-'

--- a/label_studio_converter/brush.py
+++ b/label_studio_converter/brush.py
@@ -161,7 +161,7 @@ def save_brush_images_from_annotation(
             + '-by-'
             + email
             + '-'
-            + name,
+            + sanatized_name,
         )
         image = layers[name]
         logger.debug(f'Save image to {filename}')


### PR DESCRIPTION
Ensure to replace invalid characters of label names before converting to NumPy array or PNG images.