### PR TITLE
fix: Key error 'x' when export pascal VOC

### DIFF
--- a/label_studio_converter/converter.py
+++ b/label_studio_converter/converter.py
@@ -1048,7 +1048,10 @@ class Converter(object):
                 )
                 if key is None or len(bbox[key]) == 0:
                     continue
-
+                
+                if 'x' not in bbox and bbox['format']=='rle' and bbox['type']=='RectangleLabels':
+                    continue
+                
                 name = bbox[key][0]
                 x = int(bbox['x'] / 100 * width)
                 y = int(bbox['y'] / 100 * height)


### PR DESCRIPTION
When selecting Pascal VOC export, some of RLE format intermediate annotations would appear in the rectangle group, which would lead to key error 'x'. Even though jump over these RLE annotations, our Rectangle annotations is complete. Jumping over such intermediate annotations could fix it.