### PR TITLE
chore: LEAP-293: fix the release workflow by bumping python to 3.8 also

### DIFF
--- a/.github/workflows/build_pypi.yml
+++ b/.github/workflows/build_pypi.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Configure pip cache
         uses: actions/cache@v3


### PR DESCRIPTION
...because the release workflow is failing on the build step :(