### PR TITLE
chore: LEAP-1365: bump nltk in LSC

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pandas>=0.24.0
 requests>=2.22.0,<3
 Pillow>=10.0.1
-nltk==3.6.7
+nltk>=3.8.2
 label-studio-tools>=0.0.3
 ujson
 ijson~=3.2.0.post0


### PR DESCRIPTION
Because evalme still depends on this repo, let's bump the nltk version required here.